### PR TITLE
feat: add app file settings for app router migration

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,7 +1,8 @@
 {
-  "name": "client",
+  "name": "shopping-mall-client",
   "version": "0.1.0",
   "private": true,
+  "license": "UNLICENSED",
   "scripts": {
     "dev": "next dev",
     "build": "next build",

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -1,0 +1,49 @@
+import ReactQueryClientProvider from "@/lib/util/reactQueryProvider";
+import "@/styles/Home.module.css";
+import "@/styles/globals.css";
+import { Metadata, Viewport } from "next";
+import { QueryClient } from "react-query";
+
+export const metadata: Metadata = {
+  title: "Shopping-Mall",
+  description: "Dohui Son, Shopping-Mall",
+  appleWebApp: {
+    title: "Shopping-Mall",
+    statusBarStyle: "default",
+  },
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  height: "device-height",
+  initialScale: 1,
+  minimumScale: 1,
+  maximumScale: 1,
+  interactiveWidget: "resizes-content",
+  viewportFit: "contain",
+};
+
+export default async function RootLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  const queryClient = new QueryClient();
+
+  return (
+    <html lang="en">
+      <head></head>
+      <body>
+        <ReactQueryClientProvider>
+          {/* <AppRouterCacheProvider
+            options={{
+                key:'design-system-name',
+                enableCssLayer: true }}
+          > */}
+          {children}
+          {/* </AppRouterCacheProvider> */}
+        </ReactQueryClientProvider>
+      </body>
+    </html>
+  );
+}

--- a/client/src/app/layout.tsx
+++ b/client/src/app/layout.tsx
@@ -28,8 +28,6 @@ export default async function RootLayout({
 }: {
   children: React.ReactNode;
 }) {
-  const queryClient = new QueryClient();
-
   return (
     <html lang="en">
       <head></head>

--- a/client/src/app/not-found.tsx
+++ b/client/src/app/not-found.tsx
@@ -1,0 +1,7 @@
+export default function NotFound() {
+  return (
+    <div>
+      <h1>404 Not Found</h1>
+    </div>
+  );
+}

--- a/client/src/lib/util/emotionAppRouter.tsx
+++ b/client/src/lib/util/emotionAppRouter.tsx
@@ -1,0 +1,111 @@
+// https://github.com/mui/material-ui/blob/master/packages/mui-material-nextjs/src/v13-appRouter/appRouterV13.tsx
+"use client";
+import * as React from "react";
+import createCache from "@emotion/cache";
+import { useServerInsertedHTML } from "next/navigation";
+import { CacheProvider as DefaultCacheProvider } from "@emotion/react";
+import type {
+  EmotionCache,
+  Options as OptionsOfCreateCache,
+} from "@emotion/cache";
+
+export type AppRouterCacheProviderProps = {
+  /** These are the options passed to createCache() from 'import createCache from "@emotion/cache"' */
+  options?: Partial<OptionsOfCreateCache> & {
+    /**
+     * If `true`, the generated styles are wrapped within `@layer mui`.
+     * This is useful if you want to override the Material UI's generated styles with different styling solution, like Tailwind, plain CSS etc.
+     */
+    enableCssLayer?: boolean;
+  };
+  /** By default <CacheProvider /> from 'import { CacheProvider } from "@emotion/react"' */
+  CacheProvider?: (props: {
+    value: EmotionCache;
+    children: React.ReactNode;
+  }) => React.JSX.Element | null;
+  children: React.ReactNode;
+};
+
+export default function AppRouterCacheProvider(
+  props: AppRouterCacheProviderProps
+) {
+  const { options, CacheProvider = DefaultCacheProvider, children } = props;
+
+  const [registry] = React.useState(() => {
+    const cache = createCache({
+      ...options,
+      key: options?.key ?? "design-system-name",
+    });
+    cache.compat = true;
+    const prevInsert = cache.insert;
+    let inserted: { name: string; isGlobal: boolean }[] = [];
+    cache.insert = (...args) => {
+      if (options?.enableCssLayer) {
+        args[1].styles = `@layer design-system-name {${args[1].styles}}`;
+      }
+      const [selector, serialized] = args;
+      if (cache.inserted[serialized.name] === undefined) {
+        inserted.push({
+          name: serialized.name,
+          isGlobal: !selector,
+        });
+      }
+      return prevInsert(...args);
+    };
+    const flush = () => {
+      const prevInserted = inserted;
+      inserted = [];
+      return prevInserted;
+    };
+    return { cache, flush };
+  });
+
+  useServerInsertedHTML(() => {
+    const inserted = registry.flush();
+    if (inserted.length === 0) {
+      return null;
+    }
+    let styles = "";
+    let dataEmotionAttribute = registry.cache.key;
+
+    const globals: {
+      name: string;
+      style: string;
+    }[] = [];
+
+    inserted.forEach(({ name, isGlobal }) => {
+      const style = registry.cache.inserted[name];
+
+      if (typeof style !== "boolean") {
+        if (isGlobal) {
+          globals.push({ name, style });
+        } else {
+          styles += style;
+          dataEmotionAttribute += ` ${name}`;
+        }
+      }
+    });
+
+    return (
+      <React.Fragment>
+        {globals.map(({ name, style }) => (
+          <style
+            key={name}
+            data-emotion={`${registry.cache.key}-global ${name}`}
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: style }}
+          />
+        ))}
+        {styles && (
+          <style
+            data-emotion={dataEmotionAttribute}
+            // eslint-disable-next-line react/no-danger
+            dangerouslySetInnerHTML={{ __html: styles }}
+          />
+        )}
+      </React.Fragment>
+    );
+  });
+
+  return <CacheProvider value={registry.cache}>{children}</CacheProvider>;
+}

--- a/client/src/lib/util/reactQueryProvider.tsx
+++ b/client/src/lib/util/reactQueryProvider.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { isAxiosError } from "axios";
+import { ReactNode, useState } from "react";
+import { QueryClient, QueryClientProvider } from "react-query";
+
+export default function ReactQueryClientProvider({
+  children,
+}: {
+  children: ReactNode;
+}) {
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            refetchOnWindowFocus: false,
+            retry: (count, error: unknown) => {
+              if (isAxiosError(error) && error.response?.status === 401) {
+                return count < 3;
+              }
+              return false;
+            },
+          },
+        },
+      })
+  );
+
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -16,8 +16,13 @@
     "paths": {
       "@/*": ["./src/*"]
     },
-    "typeRoots": ["./node_modules/@types"]
+    "typeRoots": ["./node_modules/@types"],
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
- app 파일을 추가하고 app router migration을 위한 기본적인 세팅을 합니다.

- Next : [**Migrating from `pages` to `app`**](https://nextjs.org/docs/pages/building-your-application/upgrading/app-router-migration#migrating-from-pages-to-app)
- [react query문서](https://tanstack.com/query/v4/docs/react/guides/ssr#using-nextjs)
- emotion cache provider - [MUI 공식 문서](https://mui.com/material-ui/guides/nextjs/#configuration)